### PR TITLE
[bugfix] a handful of fixes ahead of 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `TagAtlas` now made available in module export
+
 ### Fixed
 
 - `strToSlug` helper should be using `findOrCreateByTitle`
 - Automatically ignore splitting any title that's all uppercase or all lowercase
+- Tests where sharing the same instance of `TagAtlas` which polluted their environment and caused unexpected behaviour
 
 ## [1.0.2] - 2023-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `strToSlug` helper should be using `findOrCreateByTitle`
+- Automatically ignore splitting any title that's all uppercase or all lowercase
+
 ## [1.0.2] - 2023-01-25
 
 ### Added

--- a/src/tag-atlas.js
+++ b/src/tag-atlas.js
@@ -49,14 +49,22 @@ class TagAtlas {
 
   // Lookup by title
   findOrCreateByTitle(title, is) {
-    title = this.splitTitle(title);
-    const slug = this.slugify(title);
+    const normalisedTitle = this.splitTitle(title);
+    const slug = this.slugify(normalisedTitle);
     const found = this.findBySlug(slug);
 
     if (found) return found;
 
-    const tag = {title, slug, is};
+    const tag = {title: normalisedTitle, slug, is};
     this.tags.push(tag);
+
+    // If slug has - then lowercase title and findOrCreateByTitle again with
+    // tag as parent. This teaches the atlas that lowercase alternatives are
+    // related.
+
+    if (slug.includes('-')) {
+      this.findOrCreateByTitle(title.toLowerCase(), tag);
+    }
 
     return tag;
   }

--- a/src/tag-atlas.js
+++ b/src/tag-atlas.js
@@ -80,8 +80,9 @@ class TagAtlas {
 // Memoized copy of TagAtlas, the plugin will populate this as soon as Eleventy loads the plugin.
 let atlas;
 
+// Memoize atlas if not already set, or if set, and we have config provided.
 const memoize = (config) => {
-  if (!atlas) atlas = new TagAtlas(config);
+  if (!atlas || config) atlas = new TagAtlas(config);
   return atlas;
 }
 

--- a/src/tag-atlas.js
+++ b/src/tag-atlas.js
@@ -88,6 +88,6 @@ const memoize = (config) => {
 
 module.exports = {
   atlas: memoize,
-  strToSlug: (atlas) => (str) => atlas.findOrCreateBySlug(str).slug,
+  strToSlug: (atlas) => (str) => atlas.findOrCreateByTitle(str).slug,
   slugToStr: (atlas) => (slug) => atlas.findOrCreateBySlug(slug, true).title,
 }

--- a/src/tag-atlas.js
+++ b/src/tag-atlas.js
@@ -1,21 +1,24 @@
 class TagAtlas {
   constructor(config) {
     this.tags = [];
-    this.ignored = config.ignore;
+    this.ignored = config.ignore || [];
     this.slugify = config.slugify;
 
-    // ignore: ['PHP', 'JS', 'JavaScript'] - getTitle will return matches as these regardless of input
-    // case e.g. php -> PHP, javascript -> JavaScript
-    for (const tag of config.ignore) {
-      this.tags.push({
-        title: tag,
-        slug: this.slugify(tag)
-      });
+    if (config.ignore) {
+      // ignore: ['PHP', 'JS', 'JavaScript'] - getTitle will return matches as these regardless of input
+      // case e.g. php -> PHP, javascript -> JavaScript
+      for (const tag of config.ignore) {
+        this.tags.push({
+          title: tag,
+          slug: this.slugify(tag)
+        });
+      }
     }
 
-    // similar: {'Game Development': ['GameDev']} - GameDev will always link to Game Development
-    for (const tag of Object.keys(config.similar)) {
-      const mainTag = this.findOrCreateByTitle(tag);
+    if (config.similar) {
+      // similar: {'Game Development': ['GameDev']} - GameDev will always link to Game Development
+      for (const tag of Object.keys(config.similar)) {
+        const mainTag = this.findOrCreateByTitle(tag);
 
         for (const similarTag of config.similar[tag]) {
           this.findOrCreateByTitle(similarTag, mainTag)

--- a/src/tag-atlas.js
+++ b/src/tag-atlas.js
@@ -30,8 +30,19 @@ class TagAtlas {
   splitTitle(title) {
     if (this.ignored.find(i => i.toLowerCase() === title.toLowerCase())) return title;
 
-    const splitTitle = title.match(/[A-Z][a-z]+|[0-9]+/g);
-    return (splitTitle) ? splitTitle.join(" ") : title;
+    // TODO: Sanitise title of all punctuation?
+
+    const containsCapitals = new RegExp(/[A-Z]+/g);
+    const containsLowercase = new RegExp(/[a-z]+/g);
+
+    // if title has no capitals then return as is.
+    if (containsCapitals.test(title) === false) return title;
+
+    // else if title is all capitals then return as is.
+    if (containsLowercase.test(title) === false) return title;
+
+    // else split on capitals
+    return title.split(/([A-Z][a-z]+)/).filter(function(e){return e}).join(' ');
   }
 
   // Lookup by title
@@ -95,6 +106,7 @@ const memoize = (config) => {
 }
 
 module.exports = {
+  TagAtlas,
   atlas: memoize,
   strToSlug: (atlas) => (str) => atlas.findOrCreateByTitle(str).slug,
   slugToStr: (atlas) => (slug) => atlas.findOrCreateBySlug(slug, true).title,

--- a/src/tag-atlas.js
+++ b/src/tag-atlas.js
@@ -17,8 +17,9 @@ class TagAtlas {
     for (const tag of Object.keys(config.similar)) {
       const mainTag = this.findOrCreateByTitle(tag);
 
-      for (const similarTag of config.similar[tag]) {
-        this.findOrCreateByTitle(similarTag, mainTag.slug)
+        for (const similarTag of config.similar[tag]) {
+          this.findOrCreateByTitle(similarTag, mainTag)
+        }
       }
     }
   }
@@ -39,7 +40,7 @@ class TagAtlas {
   // Lookup by slug
   findBySlug(slug, followSimilar = false) {
     const found = this.tags.find(t => t.slug === slug);
-    if (found && followSimilar && found.is) return this.findBySlug(found.is, true);
+    if (found && followSimilar && found.is) return found.is;
     return found;
   }
 

--- a/tests/str-to-slug.test.js
+++ b/tests/str-to-slug.test.js
@@ -7,4 +7,6 @@ test('slugifies', t=>{
   t.true(slugify('hello--world') === 'hello-world')
   t.true(slugify('1 2 3') === '1-2-3')
   t.true(slugify('123') === '123')
+  t.true(slugify('11ty') === '11ty')
+  t.true(slugify('DOScember') === 'doscember')
 })

--- a/tests/tag-atlas.test.js
+++ b/tests/tag-atlas.test.js
@@ -1,35 +1,46 @@
 const test = require('ava');
-const {atlas} = require('../src/tag-atlas');
+const {TagAtlas, strToSlug, slugToStr} = require('../src/tag-atlas');
 const slugify = require('../src/str-to-slug');
 
 test('does not split titleCase or change case for ignored words', t => {
-  const tagAtlas = atlas({
+  const tagAtlas = new TagAtlas({
     slugify,
-    ignore: ['PHP', 'JS', 'JavaScript'],
-    similar: {'Game Development': ['GameDev']},
+    ignore: ['PHP', 'JS', 'JavaScript', 'MS-DOS'],
   });
 
-  t.true(tagAtlas.find('PHP').title === 'PHP');
-  t.true(tagAtlas.find('php').title === 'PHP');
-  t.true(tagAtlas.find('JavaScript').title === 'JavaScript');
-  t.true(tagAtlas.find('javascript').title === 'JavaScript');
+  const checks = {
+    'PHP':'PHP',
+    'php':'PHP',
+    'JavaScript': 'JavaScript',
+    'javascript': 'JavaScript',
+    'MS-DOS': 'MS-DOS',
+    'ms-dos': 'MS-DOS'
+  };
+
+  for (const [input, expected] of Object.entries(checks)) {
+    const result = tagAtlas.find(input);
+    t.true(result.title === expected, `[${result.title}] does not match "${expected}"`)
+  }
 });
 
 test('merges tags defined as similar', t => {
-  const tagAtlas = atlas({
+  const tagAtlas = new TagAtlas({
     slugify,
     ignore: ['PHP', 'JS', 'JavaScript'],
     similar: {'Game Development': ['GameDev']},
   });
 
-  for (const check of ['Game Development', 'GameDevelopment', 'Game Dev', 'GameDev']) {
+  const checks = ['Game Development', 'GameDevelopment', 'Game Dev', 'GameDev'];
+
+  for (const check of checks) {
     t.true(tagAtlas.find(check) !== undefined, `[${check}] should be defined`);
+
     t.true(tagAtlas.find(check).slug === 'game-development', `The slug of [${check}] should be game-development`)
   }
 });
 
 test('unknown tags return undefined', t => {
-  const tagAtlas = atlas({
+  const tagAtlas = new TagAtlas({
     slugify,
     ignore: ['PHP', 'JS', 'JavaScript'],
     similar: {'Game Development': ['GameDev']},
@@ -37,3 +48,84 @@ test('unknown tags return undefined', t => {
 
   t.true(tagAtlas.find('hello world') === undefined, `[[hello world] should be undefined`);
 });
+
+test('splitTitle correctly splits words', t => {
+  const tagAtlas = new TagAtlas({slugify});
+  const checks = {
+    '11ty': '11ty',
+    'DOS': 'DOS',
+    'JS': 'JS',
+    'JavaScript': 'Java Script',
+    'HelloWorld': 'Hello World',
+    'GameDevelopment': 'Game Development',
+    'PDFSplitAndMergeSamples': 'PDF Split And Merge Samples',
+  };
+
+  for (const [input, expected] of Object.entries(checks)) {
+    const result = tagAtlas.splitTitle(input);
+    t.true(result === expected, `[${result}] is not "${expected}"`);
+  }
+});
+
+test('strToSlug works correctly when tile atlas given no config options', t => {
+  const tagAtlas = new TagAtlas({slugify});
+  const fn = strToSlug(tagAtlas);
+  const checks = {
+    '11ty': '11ty',
+    'DOSCember': 'dos-cember',
+    'DOS': 'dos',
+    'MS-DOS': 'ms-dos',
+  };
+
+  for (const [input, output] of Object.entries(checks)) {
+    t.true(fn(input) === output, `[${fn(input)}] is not "${output}"`);
+  }
+});
+
+test('slugToStr works correctly when tile atlas given no config options', t => {
+  const tagAtlas = new TagAtlas({slugify});
+  const fn = slugToStr(tagAtlas);
+  const checks = {
+    '11ty': '11ty',
+    'doscember': 'Doscember',
+    'dos': 'Dos',
+    'js': 'Js',
+    'php': 'Php',
+    'javascript': 'Javascript',
+    'ms-dos': 'Ms Dos', // heh, but it's not aware that MS-DOS is an ignored input
+  };
+
+  for (const [input, output] of Object.entries(checks)) {
+    t.true(fn(input) === output, `[${fn(input)}] is not "${output}"`);
+  }
+});
+
+test('slugToStr returns the split title from strToSlug', t => {
+  const tagAtlas = new TagAtlas({slugify});
+  const stringToSlug = strToSlug(tagAtlas);
+  const slugToString = slugToStr(tagAtlas);
+
+  // Because tagAtlas has been taught JavaScript before javascript, it should register the lowercase variety
+  // as linked to the camelcase.
+  const checks = {
+    'JavaScript': 'Java Script',
+    'javascript': 'Java Script',
+  };
+
+  for (const [input, expected] of Object.entries(checks)) {
+    const slug = stringToSlug(input);
+    const result = slugToString(slug);
+    t.true(result === expected, `[${result}] does not match "${expected}"`);
+  }
+})
+
+test('lowercase variants added on creation', t => {
+  const tagAtlas = new TagAtlas({slugify});
+
+  // This should create two records, one for "JavaScript" and one for "javascript".
+  tagAtlas.findOrCreateByTitle('JavaScript');
+  t.true(tagAtlas.find('JavaScript').title === tagAtlas.find('javascript').title);
+
+  tagAtlas.findOrCreateByTitle('DOS');
+  t.true(tagAtlas.find('DOS').title === tagAtlas.find('dos').title);
+})


### PR DESCRIPTION
### Added

- `TagAtlas` now made available in module export

### Fixed

- `strToSlug` helper should be using `findOrCreateByTitle`
- Automatically ignore splitting any title that's all uppercase or all lowercase
- Tests where sharing the same instance of `TagAtlas` which polluted their environment and caused unexpected behaviour